### PR TITLE
Minor improvements

### DIFF
--- a/duplicates.py
+++ b/duplicates.py
@@ -2,44 +2,58 @@
 
 import os
 import argparse
+from collections import Counter
+from typing import Final, Tuple, List
 
-parser = argparse.ArgumentParser(description='Get duplicates files')
-parser.add_argument('--path', type=str, help='Path (required)')
-args = parser.parse_args()
-
-CL_BOLD = '\033[01m'
-CL_DISABLE = '\033[02m'
-CL_RED = '\033[31m'
-CL_GREEN = '\033[32m'
-CL_RESET = '\033[0m'
-
-
-def show_duplicates(duplicates):
-    for duplicate in duplicates:
-        print(f"{CL_RED}-> {duplicate[0]} x{duplicate[1]}{CL_RESET}")
-
-
-def run():
-    print("""
+TITLE_ASCII_ART: Final[str] = """
  ____  _   _ ____  _     ___ ____    _  _____ _____ ____  
 |  _ \| | | |  _ \| |   |_ _/ ___|  / \|_   _| ____/ ___| 
 | | | | | | | |_) | |    | | |     / _ \ | | |  _| \___ \ 
 | |_| | |_| |  __/| |___ | | |___ / ___ \| | | |___ ___) |
 |____/ \___/|_|   |_____|___\____/_/   \_\_| |_____|____/ 
-    """)
+"""
+
+CL_BOLD: Final[str] = "\033[01m"
+CL_DISABLE: Final[str] = "\033[02m"
+CL_RED: Final[str] = "\033[31m"
+CL_GREEN: Final[str] = "\033[32m"
+CL_RESET: Final[str] = "\033[0m"
+
+
+DuplicateInfo = Tuple[str, int]
+
+
+def show_duplicates(duplicates: List[DuplicateInfo]) -> None:
+    for filename, count in duplicates:
+        print(f"{CL_RED}-> {filename} x{count}{CL_RESET}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Get duplicates files')
+    parser.add_argument('--path', type=str, help='Path', required=True)
+    args = parser.parse_args()
+
+    print(TITLE_ASCII_ART)
     files = os.listdir(args.path)
     print(f"--------------- {CL_BOLD}files{CL_DISABLE} ---------------{CL_RESET}")
     print(files)
 
-    duplicates = list(map(lambda x: x.split("(")[0],
-                          filter(lambda y: y if y.__contains__("(") and y.__contains__(")") else None, files)))
-    result = [(dup, duplicates.count(dup) + 1) for dup in set(duplicates)]
+    duplicates = {
+        filename.split("(")[0] for filename in files
+        if '(' in filename and ')' in filename
+    }
+
+    result = [
+        (dup, count + 1)
+        for dup, count in Counter(duplicates).items()
+    ]
 
     if duplicates:
         print(f"\n--------------- {CL_BOLD}duplicates{CL_DISABLE} ---------------{CL_RESET}")
-        print(show_duplicates(result))
+        show_duplicates(result)
     else:
         print(f"\n{CL_GREEN}OK{CL_RESET}")
 
 
-run()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Move `argparser` within the main function to prevent uninitialized global run
- Set `path`  argument as required
- Extract `TITLE_ASCII_ART` to a constant to improve readability 
- Mark constant string as `Final[str]` and add other typing artifacts (`DuplicateInfo` type)
-  Improve `map(filter(` readability by using a simpler set comprehension
- change `.__contains__` for `in`
- Use counter from collection instead of calling `.count` on every elements
- do not print `None` return from `show_duplicates`
- Add `main == "__main__"` guard to allow other script importing this module directly
- rename `run` to `main`